### PR TITLE
Performance outages with on-demmand instances. Switch to spot requests

### DIFF
--- a/00_locals.tf
+++ b/00_locals.tf
@@ -1,9 +1,6 @@
 locals {
-  dc9_ami           = data.aws_ami.amazon_linux_2.id
-  dc9_instance_type = "t2.micro"
-
-  wintermute_straylight_ami           = data.aws_ami.amazon_linux_2.id
-  wintermute_straylight_instance_type = "t2.micro"
+  dc9_ami                   = data.aws_ami.amazon_linux_2.id
+  wintermute_straylight_ami = data.aws_ami.amazon_linux_2.id
 }
 
 # AMI Amazon Linux 2

--- a/02_dc9.tf
+++ b/02_dc9.tf
@@ -42,16 +42,19 @@ resource "aws_security_group" "dc9" {
   )
 }
 
-#resource "aws_spot_instance_request" "dc9" {
-resource "aws_instance" "dc9" {
-  ami = local.dc9_ami
-  #spot_price    = var.dc9_spot_price
-  instance_type = local.dc9_instance_type
+#resource "aws_instance" "dc9" {
+resource "aws_spot_instance_request" "dc9" {
+  ami           = local.dc9_ami
+  spot_price    = var.dc9_spot_price
+  instance_type = var.dc9_instance_type
   key_name      = var.key_name
 
   subnet_id                   = aws_subnet.public.id
   vpc_security_group_ids      = [aws_security_group.dc9.id]
   associate_public_ip_address = true
+
+  wait_for_fulfillment = true
+  spot_type            = "one-time"
 
   tags = merge(
     var.tags,

--- a/02_wintermute_straylight.tf
+++ b/02_wintermute_straylight.tf
@@ -51,16 +51,19 @@ resource "aws_security_group" "wintermute_straylight" {
   )
 }
 
-#resource "aws_spot_instance_request" "wintermute_straylight" {
-resource "aws_instance" "wintermute_straylight" {
-  ami = local.wintermute_straylight_ami
-  #spot_price    = var.wintermute_straylight_spot_price
-  instance_type = local.wintermute_straylight_instance_type
+#resource "aws_instance" "wintermute_straylight" {
+resource "aws_spot_instance_request" "wintermute_straylight" {
+  ami           = local.wintermute_straylight_ami
+  spot_price    = var.wintermute_straylight_spot_price
+  instance_type = var.wintermute_straylight_instance_type
   key_name      = var.key_name
 
   subnet_id                   = aws_subnet.private.id
   vpc_security_group_ids      = [aws_security_group.wintermute_straylight.id]
   associate_public_ip_address = false
+
+  wait_for_fulfillment = true
+  spot_type            = "one-time"
 
   tags = merge(
     var.tags,

--- a/99_output.tf
+++ b/99_output.tf
@@ -1,13 +1,13 @@
 output "dc9_public_ip" {
-  value = aws_instance.dc9.public_ip
+  value = aws_spot_instance_request.dc9.public_ip
 }
 
 output "dc9_private_ip" {
-  value = aws_instance.dc9.private_ip
+  value = aws_spot_instance_request.dc9.private_ip
 }
 
 output "wintermute_straylight_private_ip" {
-  value = aws_instance.wintermute_straylight.private_ip
+  value = aws_spot_instance_request.wintermute_straylight.private_ip
 }
 
 output "ansibleinventory" {
@@ -18,7 +18,7 @@ output "ansibleinventory" {
         dc9 = {
           hosts = {
             dc9 = {
-              ansible_host                 = aws_instance.dc9.public_ip
+              ansible_host                 = aws_spot_instance_request.dc9.public_ip
               ansible_connection           = "ssh"
               ansible_user                 = "ec2-user"
               ansible_ssh_private_key_file = var.local_privkey_path
@@ -29,11 +29,11 @@ output "ansibleinventory" {
         wintermute_straylight = {
           hosts = {
             wintermute_straylight = {
-              ansible_host                 = aws_instance.wintermute_straylight.private_ip
+              ansible_host                 = aws_spot_instance_request.wintermute_straylight.private_ip
               ansible_connection           = "ssh"
               ansible_user                 = "ec2-user"
               ansible_ssh_private_key_file = var.local_privkey_path
-              ansible_ssh_common_args      = "-o ProxyCommand=\"ssh -o StrictHostKeyChecking=no -W %h:%p -i ${var.local_privkey_path} -q ec2-user@${aws_instance.dc9.public_ip}\""
+              ansible_ssh_common_args      = "-o ProxyCommand=\"ssh -o StrictHostKeyChecking=no -W %h:%p -i ${var.local_privkey_path} -q ec2-user@${aws_spot_instance_request.dc9.public_ip}\""
               ansible_python_interpreter   = "python3"
               postfix_mynetworks           = [aws_subnet.public.cidr_block, aws_subnet.private.cidr_block]
             }

--- a/99_variables.tf
+++ b/99_variables.tf
@@ -38,3 +38,32 @@ variable local_privkey_path {
   default     = "~/.ssh/kiddie.id_rsa"
   description = "Kiddie PubKey Name for Management"
 }
+
+
+variable dc9_instance_type {
+  type = string
+  # 2vcpu + 2G ==> 0.0204 $ , 67% disc.
+  default     = "t3a.small"
+  description = "DC-9 instance type"
+}
+
+variable dc9_spot_price {
+  type = string
+  # Spot price = 0.0204 * (1- 0.67) = 0.006732
+  default     = "0.008"
+  description = "DC-9 spot instance price threshold"
+}
+
+variable wintermute_straylight_instance_type {
+  type = string
+  # 2vcpu + 2G ==> 0.0204 $ , 67% disc.
+  default     = "t3a.small" # NOTE: Needs IPv6 support
+  description = "Wintermute Straylight instance type"
+}
+
+variable wintermute_straylight_spot_price {
+  type = string
+  # Spot price = 0.0204 * (1- 0.67) = 0.006732
+  default     = "0.008"
+  description = "Wintermute Straylight spot instance price threshold"
+}


### PR DESCRIPTION
There are some occasional performance outages, specially when pivoting. Free tier t2.micro instances have too few resources.

Better use spot instances with more resources: t3a.small seems to be OK.